### PR TITLE
Fix/tensorflow21

### DIFF
--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -91,7 +91,8 @@ class core_trainer:
         if self.nb_gpus > 1:
             mirrored_strategy = tensorflow.distribute.MirroredStrategy()
             with mirrored_strategy.scope():
-                self.initialize_network()
+                if auto_compile:
+                    self.initialize_network()
 
                 self.initialize_callbacks()
 

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -364,7 +364,8 @@ class transfer_trainer(core_trainer):
         if self.nb_gpus > 1:
             mirrored_strategy = tensorflow.distribute.MirroredStrategy()
             with mirrored_strategy.scope():
-                self.initialize_network()
+                if auto_compile:
+                    self.initialize_network()
 
                 self.initialize_callbacks()
 
@@ -400,7 +401,5 @@ class transfer_trainer(core_trainer):
 
     def initialize_network(self):
         self.local_model = load_model(
-            self.model_path,
-            custom_objects={"annealed_loss":
-                            lc.loss_selector("annealed_loss")},
+            self.model_path
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 tensorflow==2.2.2
 nibabel
-h5py
+h5py==2.10.0
 matplotlib
 numpy
 python-dateutil
-scipy
+scipy==1.4.1
 tifffile
 s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==2.1
+tensorflow==2.2.2
 nibabel
 h5py
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-tensorflow==2.3.0
-tensorflow-estimator
+tensorflow==2.1
 nibabel
 h5py
 matplotlib
-numpy==1.16.0
+numpy
 python-dateutil
-scipy==1.4.1
+scipy
 tifffile
 s3fs


### PR DESCRIPTION
- Downgrade Tensorflow version to avoid bug in training creating very large tensors
- Tested multi-GPU on an 8GPU machine and found that 2.2.2 works well while 2.1 has issues with two photon model