### PR TITLE
allow/non/lims/filepaths

### DIFF
--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -7,6 +7,7 @@ import tifffile
 import nibabel as nib
 import s3fs
 import glob
+import warnings
 from deepinterpolation.generic import JsonLoader
 
 
@@ -1171,5 +1172,8 @@ class MovieJSONGenerator(DeepGenerator):
             movie_obj.close()
 
             return input_full, output_full
-        except Exception:
-            print("Issues with " + str(self.lims_id))
+        except Exception as err:
+            msg = f"Issues with {local_lims}\n"
+            msg += f"Error: {str(err)}\n"
+            msg += "moving on\n"
+            warnings.warn(msg)

--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -1115,7 +1115,6 @@ class MovieJSONGenerator(DeepGenerator):
                 motion_path = local_path
             else:
                 _filenames = ["motion_corrected_video.h5", "concat_31Hz_0.h5"]
-                motion_path = []
                 for _filename in _filenames:
                     _filepath = os.path.join(local_path, "processed", _filename)
                     if os.path.exists(_filepath) and not os.path.islink(

--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -1117,7 +1117,10 @@ class MovieJSONGenerator(DeepGenerator):
             else:
                 _filenames = ["motion_corrected_video.h5", "concat_31Hz_0.h5"]
                 for _filename in _filenames:
-                    _filepath = os.path.join(local_path, "processed", _filename)
+                    _filepath = os.path.join(local_path,
+                                             "processed",
+                                             _filename)
+
                     if os.path.exists(_filepath) and not os.path.islink(
                         _filepath
                     ):  # Path exists and is not symbolic
@@ -1125,7 +1128,7 @@ class MovieJSONGenerator(DeepGenerator):
                         break
 
             if motion_path is None:
-                msg = f"unable to find valid movie file for path\n"
+                msg = "unable to find valid movie file for path\n"
                 msg += f"{local_path}"
                 raise RuntimeError(msg)
 
@@ -1141,8 +1144,8 @@ class MovieJSONGenerator(DeepGenerator):
                 output_full = np.zeros([1, 512, 512, 1])
 
                 input_index = np.arange(
-                    output_frame - self.pre_frame - self.pre_post_omission,
-                    output_frame + self.post_frame + self.pre_post_omission + 1,
+                  output_frame - self.pre_frame - self.pre_post_omission,
+                  output_frame + self.post_frame + self.pre_post_omission + 1,
                 )
                 input_index = input_index[input_index != output_frame]
 

--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -1128,47 +1128,46 @@ class MovieJSONGenerator(DeepGenerator):
                 msg += f"{local_path}"
                 raise RuntimeError(msg)
 
-            movie_obj = h5py.File(motion_path, "r")
+            with h5py.File(motion_path, "r") as movie_obj:
 
-            local_frame_data = self.frame_data_location[local_lims]
-            output_frame = local_frame_data["frames"][local_img]
-            local_mean = local_frame_data["mean"]
-            local_std = local_frame_data["std"]
+                local_frame_data = self.frame_data_location[local_lims]
+                output_frame = local_frame_data["frames"][local_img]
+                local_mean = local_frame_data["mean"]
+                local_std = local_frame_data["std"]
 
-            input_full = np.zeros(
-                [1, 512, 512, self.pre_frame + self.post_frame])
-            output_full = np.zeros([1, 512, 512, 1])
+                input_full = np.zeros(
+                    [1, 512, 512, self.pre_frame + self.post_frame])
+                output_full = np.zeros([1, 512, 512, 1])
 
-            input_index = np.arange(
-                output_frame - self.pre_frame - self.pre_post_omission,
-                output_frame + self.post_frame + self.pre_post_omission + 1,
-            )
-            input_index = input_index[input_index != output_frame]
+                input_index = np.arange(
+                    output_frame - self.pre_frame - self.pre_post_omission,
+                    output_frame + self.post_frame + self.pre_post_omission + 1,
+                )
+                input_index = input_index[input_index != output_frame]
 
-            for index_padding in np.arange(self.pre_post_omission + 1):
-                input_index = input_index[input_index !=
-                                          output_frame - index_padding]
-                input_index = input_index[input_index !=
-                                          output_frame + index_padding]
+                for index_padding in np.arange(self.pre_post_omission + 1):
+                    input_index = input_index[input_index !=
+                                              output_frame - index_padding]
+                    input_index = input_index[input_index !=
+                                              output_frame + index_padding]
 
-            data_img_input = movie_obj["data"][input_index, :, :]
-            data_img_output = movie_obj["data"][output_frame, :, :]
+                data_img_input = movie_obj["data"][input_index, :, :]
+                data_img_output = movie_obj["data"][output_frame, :, :]
 
-            data_img_input = np.swapaxes(data_img_input, 1, 2)
-            data_img_input = np.swapaxes(data_img_input, 0, 2)
+                data_img_input = np.swapaxes(data_img_input, 1, 2)
+                data_img_input = np.swapaxes(data_img_input, 0, 2)
 
-            img_in_shape = data_img_input.shape
-            img_out_shape = data_img_output.shape
+                img_in_shape = data_img_input.shape
+                img_out_shape = data_img_output.shape
 
-            data_img_input = (data_img_input.astype(
-                "float") - local_mean) / local_std
-            data_img_output = (data_img_output.astype(
-                "float") - local_mean) / local_std
-            input_full[0, : img_in_shape[0],
-                       : img_in_shape[1], :] = data_img_input
-            output_full[0, : img_out_shape[0],
-                        : img_out_shape[1], 0] = data_img_output
-            movie_obj.close()
+                data_img_input = (data_img_input.astype(
+                    "float") - local_mean) / local_std
+                data_img_output = (data_img_output.astype(
+                    "float") - local_mean) / local_std
+                input_full[0, : img_in_shape[0],
+                           : img_in_shape[1], :] = data_img_input
+                output_full[0, : img_out_shape[0],
+                            : img_out_shape[1], 0] = data_img_output
 
             return input_full, output_full
         except Exception as err:

--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -1109,15 +1109,24 @@ class MovieJSONGenerator(DeepGenerator):
             # Initialization
             local_path = self.frame_data_location[local_lims]["path"]
 
-            _filenames = ["motion_corrected_video.h5", "concat_31Hz_0.h5"]
-            motion_path = []
-            for _filename in _filenames:
-                _filepath = os.path.join(local_path, "processed", _filename)
-                if os.path.exists(_filepath) and not os.path.islink(
-                    _filepath
-                ):  # Path exists and is not symbolic
-                    motion_path = _filepath
-                    break
+            motion_path = None
+            if os.path.isfile(local_path):
+                motion_path = local_path
+            else:
+                _filenames = ["motion_corrected_video.h5", "concat_31Hz_0.h5"]
+                motion_path = []
+                for _filename in _filenames:
+                    _filepath = os.path.join(local_path, "processed", _filename)
+                    if os.path.exists(_filepath) and not os.path.islink(
+                        _filepath
+                    ):  # Path exists and is not symbolic
+                        motion_path = _filepath
+                        break
+
+            if motion_path is None:
+                msg = f"unable to find valid movie file for path\n"
+                msg += f"{local_path}"
+                raise RuntimeError(msg)
 
             movie_obj = h5py.File(motion_path, "r")
 

--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -1039,6 +1039,7 @@ class MovieJSONGenerator(DeepGenerator):
             self.frame_data_location = json.load(json_handle)
 
         self.lims_id = list(self.frame_data_location.keys())
+        self.lims_id.sort()
         self.nb_lims = len(self.lims_id)
         self.img_per_movie = len(
             self.frame_data_location[self.lims_id[0]]["frames"])

--- a/tests/test_movie_json_generator.py
+++ b/tests/test_movie_json_generator.py
@@ -1,0 +1,201 @@
+import pytest
+import h5py
+import json
+import tempfile
+import pathlib
+import numpy as np
+from deepinterpolation.generator_collection import MovieJSONGenerator
+
+
+@pytest.fixture(scope='session')
+def frame_list_fixture():
+    """
+    Indexes of frames returned by MovieJSONGenerator
+    """
+    return [4, 3, 5, 7]
+
+
+@pytest.fixture(scope='session')
+def movie_path_list_fixture(tmpdir_factory):
+    """
+    yields a list of paths to test movie files
+    """
+    path_list = []
+
+    parent_tmpdir = tmpdir_factory.mktemp('movies_for_test')
+    rng = np.random.default_rng(172312)
+    this_dir = tempfile.mkdtemp(dir=parent_tmpdir)
+    this_path = tempfile.mkstemp(dir=this_dir, suffix='.h5')[1]
+    with h5py.File(this_path, 'w') as out_file:
+        out_file.create_dataset('data',
+                                data=rng.random((12, 512, 512)))
+
+    path_list.append(this_path)
+
+    this_dir = tempfile.mkdtemp(dir=parent_tmpdir)
+    this_dir = pathlib.Path(this_dir) / 'processed'
+    this_dir.mkdir()
+    this_path = this_dir / 'concat_31Hz_0.h5'
+    with h5py.File(this_path, 'w') as out_file:
+        out_file.create_dataset('data',
+                                data=rng.random((12, 512, 512)))
+    path_list.append(str(this_path.resolve().absolute()))
+
+    this_dir = tempfile.mkdtemp(dir=parent_tmpdir)
+    this_dir = pathlib.Path(this_dir) / 'processed'
+    this_dir.mkdir()
+    this_path = this_dir / 'motion_corrected_video.h5'
+    with h5py.File(this_path, 'w') as out_file:
+        out_file.create_dataset('data',
+                                data=rng.random((12, 512, 512)))
+    path_list.append(str(this_path.resolve().absolute()))
+
+    yield path_list
+
+    for this_path in path_list:
+        this_path = pathlib.Path(this_path)
+        if this_path.is_file():
+            this_path.unlink()
+
+
+@pytest.fixture(scope='session')
+def json_frame_specification_fixture(movie_path_list_fixture,
+                                     tmpdir_factory,
+                                     frame_list_fixture):
+    """
+    yields a dict with the following key/value pairs
+
+    'json_path' -- path to the file specifying the
+                   movies/frames for the generator
+
+    'expected_input' -- list of expected input
+                        datasets returned by the generator
+
+    'expected_output' -- list of expected output
+                         datasets returned by the generator
+    """
+
+    params = dict()
+
+    for ii, movie_path in enumerate(movie_path_list_fixture):
+        this_params = dict()
+        if ii > 0:
+            movie_path = str(pathlib.Path(movie_path).parent.parent)
+        this_params['path'] = movie_path
+        this_params['frames'] = frame_list_fixture
+        this_params['mean'] = (ii+1)*2.1
+        this_params['std'] = (ii+1)*3.4
+        params[str(ii)] = this_params
+
+    tmpdir = tmpdir_factory.mktemp('frame_specification')
+    json_path = tempfile.mkstemp(
+                    dir=tmpdir,
+                    prefix='frame_specification_params_',
+                    suffix='.json')[1]
+    with open(json_path, 'w') as out_file:
+        out_file.write(json.dumps(params))
+
+    # now construct the input and output frames that
+    # we expect this generator to yield
+    expected_output_frames = []
+    expected_input_frames = []
+
+    path_to_data = dict()
+    for movie_path in movie_path_list_fixture:
+        with h5py.File(movie_path, 'r') as in_file:
+            data = in_file['data'][()]
+        path_to_data[movie_path] = data
+
+    for i_frame in range(len(frame_list_fixture)):
+        for ii in range(len(movie_path_list_fixture)):
+            this_params = params[str(ii)]
+            mu = this_params['mean']
+            std = this_params['std']
+            movie_path = movie_path_list_fixture[ii]
+            data = path_to_data[movie_path]
+            frame = frame_list_fixture[i_frame]
+            output_data = (data[frame, :, :] - mu)/std
+
+            input_indexes = np.array([frame-2, frame-1, frame+1, frame+2])
+            input_data = (data[input_indexes, :, :]-mu)/std
+
+            expected_output_frames.append(output_data)
+            expected_input_frames.append(input_data)
+
+    yield {'json_path': json_path,
+           'expected_input': expected_input_frames,
+           'expected_output': expected_output_frames}
+
+    json_path = pathlib.Path(json_path)
+    if json_path.is_file():
+        json_path.unlink()
+
+
+@pytest.fixture(scope='session')
+def json_generator_params_fixture(
+        tmpdir_factory,
+        json_frame_specification_fixture):
+    """
+    yields the path to the JSON configuration file for the MovieJSONGenerator
+    """
+
+    tmpdir = tmpdir_factory.mktemp('json_generator_params')
+    json_path = tempfile.mkstemp(dir=tmpdir,
+                                 prefix='movie_json_generator_params_',
+                                 suffix='.json')[1]
+
+    params = dict()
+    params['pre_post_omission'] = 0
+    params['total_samples'] = -1
+    params['name'] = 'MovieJSONGenerator'
+    params['batch_size'] = 1
+    params['start_frame'] = 0
+    params['end_frame'] = -1
+    params['pre_frame'] = 2
+    params['post_frame'] = 2
+    params['randomize'] = True
+    params['data_path'] = json_frame_specification_fixture['json_path']
+    params['steps_per_epoch'] = -1
+    params['train_path'] = json_frame_specification_fixture['json_path']
+    params['type'] = 'generator'
+
+    with open(json_path, 'w') as out_file:
+        out_file.write(json.dumps(params, indent=2))
+
+    yield json_path
+
+    json_path = pathlib.Path(json_path)
+    if json_path.is_file():
+        json_path.unlink()
+
+
+def test_movie_json_generator(
+        movie_path_list_fixture,
+        json_frame_specification_fixture,
+        json_generator_params_fixture,
+        frame_list_fixture):
+
+    expected_input = json_frame_specification_fixture['expected_input']
+    expected_output = json_frame_specification_fixture['expected_output']
+
+    generator = MovieJSONGenerator(json_generator_params_fixture)
+    lims_id_list = generator.lims_id
+
+    n_frames = len(frame_list_fixture)
+    dataset_ct = 0
+
+    for dataset in generator:
+        # check that the dataset contains the expected input/output frames
+        expected_i = expected_input[dataset_ct]
+        expected_o = expected_output[dataset_ct]
+
+        actual_o = dataset[1][0, :, :, 0]
+        np.testing.assert_array_equal(actual_o, expected_o)
+
+        actual_i = dataset[0][0, :, :, :].transpose(2, 0, 1)
+        np.testing.assert_array_equal(actual_i, expected_i)
+
+        dataset_ct += 1
+
+    # make sure we got the expected number of datasets
+    assert dataset_ct == len(lims_id_list)*n_frames


### PR DESCRIPTION
This PR makes it possible for users to specify filepaths that are not specific to the Allen Institute LIMS when instantiating a MovieJSONGenerator. This will be useful for outside users, and Allen Institute users, since the naming convention for our motion corrected movies may change.

I would also like to talk about that massive try/except block in `MovieJSONGenerator.__data_generation__` My experience has been that it has obscured failures that I actually want to fix in my configuration files. Is there a reason we don't want to alert users when their input data is ill-formed?