### PR TITLE
Pass same multiprocessing settings to evaluate as to fit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
           command: |
             pip install .
             pip install -r test_requirements.txt
-            pip install tensorflow --upgrade
           name: Install
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
             - image: cimg/python:<< parameters.tag >>
         parameters:
             tag:
-                default: "3.7"
+                default: "3.8"
                 description: The `cimg/python` Docker image version tag.
                 type: string
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
             - image: cimg/python:<< parameters.tag >>
         parameters:
             tag:
-                default: "3.8"
+                default: "3.7"
                 description: The `cimg/python` Docker image version tag.
                 type: string
 

--- a/deepinterpolation/generator_collection.py
+++ b/deepinterpolation/generator_collection.py
@@ -5,7 +5,6 @@ import h5py
 import tensorflow.keras as keras
 import tifffile
 import nibabel as nib
-import s3fs
 import glob
 from deepinterpolation.generic import JsonLoader
 
@@ -899,11 +898,6 @@ class OphysGenerator(SequentialGenerator):
         "Initialization"
         super().__init__(json_path)
 
-        if "from_s3" in self.json_data.keys():
-            self.from_s3 = self.json_data["from_s3"]
-        else:
-            self.from_s3 = False
-
         # For backward compatibility
         if "train_path" in self.json_data.keys():
             self.raw_data_file = self.json_data["train_path"]
@@ -912,12 +906,7 @@ class OphysGenerator(SequentialGenerator):
 
         self.batch_size = self.json_data["batch_size"]
 
-        if self.from_s3:
-            s3_filesystem = s3fs.S3FileSystem()
-            raw_data = h5py.File(
-                s3_filesystem.open(self.raw_data_file, "rb"), "r")["data"]
-        else:
-            raw_data = h5py.File(self.raw_data_file, "r")["data"]
+        raw_data = h5py.File(self.raw_data_file, "r")["data"]
 
         self.total_frame_per_movie = int(raw_data.shape[0])
 
@@ -951,13 +940,7 @@ class OphysGenerator(SequentialGenerator):
 
     def __data_generation__(self, index_frame):
         "Generates data containing batch_size samples"
-
-        if self.from_s3:
-            s3_filesystem = s3fs.S3FileSystem()
-            movie_obj = h5py.File(s3_filesystem.open(
-                self.raw_data_file, "rb"), "r")
-        else:
-            movie_obj = h5py.File(self.raw_data_file, "r")
+        movie_obj = h5py.File(self.raw_data_file, "r")
 
         input_full = np.zeros([1, 512, 512, self.pre_frame + self.post_frame])
         output_full = np.zeros([1, 512, 512, 1])

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -242,7 +242,7 @@ class core_trainer:
                 shuffle=False,
                 use_multiprocessing=self.use_multiprocessing,
                 callbacks=self.callbacks_list,
-                initial_epoch=0,
+                initial_epoch=0
             )
         else:
             self.model_train = self.local_model.fit(
@@ -426,7 +426,11 @@ class transfer_trainer(core_trainer):
         # For transfer learning, knowing the
         # baseline validation loss is important
         self.baseline_val_loss = self.local_model.evaluate(
-            self.local_test_generator)
+            self.local_test_generator,
+            max_queue_size=32,
+            workers=self.workers,
+            use_multiprocessing=self.use_multiprocessing
+        )
 
     def initialize_network(self):
         self.__load_model()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy
 python-dateutil
 scipy
 tifffile
-s3fs==2021.11.1
+s3fs
 argschema==2.0.2
 mlflow==1.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ numpy
 python-dateutil
 scipy
 tifffile
-s3fs
+s3fs==2021.11.1
 argschema==2.0.2
 mlflow==1.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ numpy
 python-dateutil
 scipy
 tifffile
-s3fs
 argschema==2.0.2
 mlflow==1.14.1


### PR DESCRIPTION
The call to `model.evaluate` when evaluating initial validation loss when finetuning uses the default settings for multiprocessing. This means multiprocessing is disabled.

This has significant implications for the time it takes to do a forward pass of the validation set. 

In a small test, it took 37 seconds to call `model.evaluate` with no multiprocessing (current setting) compared with 17 seconds with this PR.

This has big implications when the data size is big. To evaluate 40,000 examples, it took 48 hours in the initial `model.evaluate` call and only 9 hours in the `model.fit` call with multiprocessing. This validation size was too big, but still it shows the issue.