### PR TITLE
Update default seed

### DIFF
--- a/deepinterpolation/cli/schemas.py
+++ b/deepinterpolation/cli/schemas.py
@@ -185,7 +185,7 @@ class GeneratorSchema(argschema.schemas.DefaultSchema):
 
     seed = argschema.fields.Int(
         required=False,
-        default=-1234,
+        default=1234,
         description="Seed used with the randomize parameter to shuffle \
             selected frames in the generator.",
     )


### PR DESCRIPTION
Negative numbers are not valid seeds to np.random.default_rng

```
  File "/envs/ophys_etl/lib/python3.8/site-packages/deepinterpolation/generator_collection.py", line 1254, in __init__
    rng = np.random.default_rng(self.seed)
  File "_generator.pyx", line 4849, in numpy.random._generator.default_rng
  File "_pcg64.pyx", line 121, in numpy.random._pcg64.PCG64.__init__
  File "bit_generator.pyx", line 517, in numpy.random.bit_generator.BitGenerator.__init__
  File "bit_generator.pyx", line 307, in numpy.random.bit_generator.SeedSequence.__init__
  File "bit_generator.pyx", line 381, in numpy.random.bit_generator.SeedSequence.get_assembled_entropy
  File "bit_generator.pyx", line 138, in numpy.random.bit_generator._coerce_to_uint32_array
  File "bit_generator.pyx", line 68, in numpy.random.bit_generator._int_to_uint32_array
ValueError: expected non-negative integer
```