### PR TITLE
Add logging

### DIFF
--- a/deepinterpolation/cli/fine_tuning.py
+++ b/deepinterpolation/cli/fine_tuning.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from typing import Dict, Optional, List
 
 import argschema
 
@@ -9,8 +10,13 @@ from deepinterpolation.generic import ClassLoader
 
 
 class FineTuning(argschema.ArgSchemaParser):
-    def __init__(self):
+    def __init__(
+            self,
+            input_data: Dict,
+            args: Optional[List] = None):
         super().__init__(
+            input_data=input_data,
+            args=args,
             schema_type=FineTuningInputSchema)
         for handler in logging.root.handlers[:]:
             logging.root.removeHandler(handler)

--- a/deepinterpolation/cli/fine_tuning.py
+++ b/deepinterpolation/cli/fine_tuning.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from pathlib import Path
 from typing import Dict, Optional, List
 
@@ -24,7 +25,8 @@ class FineTuning(argschema.ArgSchemaParser):
         logging.basicConfig(
             format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
             datefmt='%Y-%m-%d %H:%M:%S',
-            level=self.logger.level
+            level=self.logger.level,
+            stream=sys.stdout
         )
         logger = logging.getLogger(type(self).__name__)
         logger.setLevel(level=self.logger.level)

--- a/deepinterpolation/cli/fine_tuning.py
+++ b/deepinterpolation/cli/fine_tuning.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 
 import argschema
@@ -8,11 +9,22 @@ from deepinterpolation.generic import ClassLoader
 
 
 class FineTuning(argschema.ArgSchemaParser):
-    default_schema = FineTuningInputSchema
+    def __init__(self):
+        super().__init__(
+            schema_type=FineTuningInputSchema)
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
+        logging.basicConfig(
+            format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+            level=self.logger.level
+        )
+        logger = logging.getLogger(type(self).__name__)
+        logger.setLevel(level=self.logger.level)
+        self.logger = logger
 
     def run(self):
-        self.logger.name = type(self).__name__
-
         uid = self.args["run_uid"]
 
         outdir = Path(self.args["finetuning_params"]["output_dir"])

--- a/deepinterpolation/cli/schemas.py
+++ b/deepinterpolation/cli/schemas.py
@@ -715,6 +715,13 @@ class FineTuningSchema(argschema.schemas.DefaultSchema):
             training becomes limited either by RAM or CPU usage.",
     )
 
+    verbose = argschema.fields.Int(
+        default=1,
+        description=(
+            'See `verbose` argument in '
+            'https://keras.io/api/models/model_training_apis/#fit-method')
+    )
+
 
 class NetworkSchema(argschema.schemas.DefaultSchema):
     name = argschema.fields.String(

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -228,31 +228,21 @@ class core_trainer:
         if self.caching_validation:
             self.cache_validation()
 
-        if self.steps_per_epoch > 0:
-            self.model_train = self.local_model.fit(
-                self.local_generator,
-                validation_data=self.local_test_generator,
-                steps_per_epoch=self.steps_per_epoch,
-                epochs=self.epochs,
-                max_queue_size=32,
-                workers=self.workers,
-                shuffle=False,
-                use_multiprocessing=self.use_multiprocessing,
-                callbacks=self.callbacks_list,
-                initial_epoch=0,
-            )
-        else:
-            self.model_train = self.local_model.fit(
-                self.local_generator,
-                validation_data=self.local_test_generator,
-                epochs=self.epochs,
-                max_queue_size=32,
-                workers=self.workers,
-                shuffle=False,
-                use_multiprocessing=True,
-                callbacks=self.callbacks_list,
-                initial_epoch=0,
-            )
+        steps_per_epoch = self.steps_per_epoch if self.steps_per_epoch > 0 \
+            else None
+
+        self.model_train = self.local_model.fit(
+            self.local_generator,
+            validation_data=self.local_test_generator,
+            steps_per_epoch=steps_per_epoch,
+            epochs=self.epochs,
+            max_queue_size=32,
+            workers=self.workers,
+            shuffle=False,
+            use_multiprocessing=self.use_multiprocessing,
+            callbacks=self.callbacks_list,
+            initial_epoch=0,
+        )
 
     def finalize(self):
         draw_plot = True

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -166,7 +166,8 @@ class core_trainer:
             test_data=self.local_test_generator,
             workers=self.workers,
             use_multiprocessing=self.use_multiprocessing,
-            verbose=self.verbose
+            verbose=self.verbose,
+            logger=self._logger
         )
 
         callbacks_list = [validation_callback]
@@ -348,13 +349,15 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
             test_data: tensorflow.keras.utils.Sequence,
             workers: int,
             use_multiprocessing: bool,
-            verbose: int
+            verbose: int,
+            logger: logging.Logger
     ):
         self._model_checkpoint_callback = model_checkpoint_callback
         self._test_data = test_data
         self._workers = workers
         self._use_multiprocessing = use_multiprocessing
         self._verbose = verbose
+        self._logger = logger
 
     def on_epoch_begin(self, epoch, logs=None):
         self._logger.info(f'Epoch {epoch} train')

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import warnings
@@ -67,6 +68,7 @@ class core_trainer:
         self.period_save = json_data["period_save"]
         self.learning_rate = json_data["learning_rate"]
         self.verbose = json_data["verbose"]
+        self._logger = logging.getLogger(__name__)
 
         if "checkpoints_dir" in json_data.keys():
             self.checkpoints_dir = json_data["checkpoints_dir"]
@@ -354,9 +356,12 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
         self._verbose = verbose
 
     def on_epoch_begin(self, epoch):
+        self._logger.info(f'Epoch {epoch} train')
         self._model_checkpoint_callback.on_epoch_begin(epoch=epoch)
 
     def on_epoch_end(self, epoch):
+        self._logger.info(f'Epoch {epoch} validation')
+
         self.local_model.evaluate(
             x=self._test_data,
             max_queue_size=32,

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -66,6 +66,7 @@ class core_trainer:
         self.nb_gpus = json_data["nb_gpus"]
         self.period_save = json_data["period_save"]
         self.learning_rate = json_data["learning_rate"]
+        self.verbose = json_data["verbose"]
 
         if "checkpoints_dir" in json_data.keys():
             self.checkpoints_dir = json_data["checkpoints_dir"]
@@ -242,6 +243,7 @@ class core_trainer:
             use_multiprocessing=self.use_multiprocessing,
             callbacks=self.callbacks_list,
             initial_epoch=0,
+            verbose=self.verbose
         )
 
     def finalize(self):

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -356,11 +356,11 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
         self._use_multiprocessing = use_multiprocessing
         self._verbose = verbose
 
-    def on_epoch_begin(self, epoch):
+    def on_epoch_begin(self, epoch, logs=None):
         self._logger.info(f'Epoch {epoch} train')
-        self._model_checkpoint_callback.on_epoch_begin(epoch=epoch)
+        self._model_checkpoint_callback.on_epoch_begin(epoch=epoch, logs=logs)
 
-    def on_epoch_end(self, epoch):
+    def on_epoch_end(self, epoch, logs=None):
         self._logger.info(f'Epoch {epoch} validation')
 
         self.local_model.evaluate(

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -332,6 +332,7 @@ class core_trainer:
         """Validation loss"""
         return self._val_losses
 
+
 # This is a helper class to fix an issue in tensorflow 2.0.
 # the on_epoch_end callback from sequences is not called.
 class OnEpochEnd(tensorflow.keras.callbacks.Callback):
@@ -434,7 +435,8 @@ class transfer_trainer(core_trainer):
     @property
     def output_model_file_path(self):
         return os.path.join(
-            self.output_dir, self.run_uid + "_" + self.model_string + "_transfer_model.h5"
+            self.output_dir, self.run_uid + "_" + self.model_string +
+            "_transfer_model.h5"
         )
 
     def initialize_network(self):

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -150,11 +150,11 @@ class core_trainer:
 
         checkpoint_path = os.path.join(
             self.checkpoints_dir,
-            self.run_uid + "_" + self.model_string + "-{epoch:04d}-{val_loss:.4f}.h5",
+            self.run_uid + "_" + self.model_string + "-{epoch:04d}-{loss:.4f}.h5",
         )
         checkpoint = CustomModelCheckpoint(
             checkpoint_path,
-            monitor="val_loss",
+            monitor="loss",
             verbose=self.verbose,
             save_best_only=True,
             mode="min",

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -162,6 +162,7 @@ class core_trainer:
         )
 
         validation_callback = ValidationCallback(
+            model=self.local_model,
             model_checkpoint_callback=checkpoint,
             test_data=self.local_test_generator,
             workers=self.workers,
@@ -345,6 +346,7 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
     """
     def __init__(
             self,
+            model: tensorflow.keras.Model,
             model_checkpoint_callback: CustomModelCheckpoint,
             test_data: tensorflow.keras.utils.Sequence,
             workers: int,
@@ -352,6 +354,7 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
             verbose: int,
             logger: logging.Logger
     ):
+        self._model = model
         self._model_checkpoint_callback = model_checkpoint_callback
         self._test_data = test_data
         self._workers = workers
@@ -360,13 +363,13 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
         self._logger = logger
 
     def on_epoch_begin(self, epoch, logs=None):
-        self._logger.info(f'Epoch {epoch} train')
+        self._logger.info(f'Epoch {epoch+1} train')
         self._model_checkpoint_callback.on_epoch_begin(epoch=epoch, logs=logs)
 
     def on_epoch_end(self, epoch, logs=None):
-        self._logger.info(f'Epoch {epoch} validation')
+        self._logger.info(f'Epoch {epoch+1} validation')
 
-        self.local_model.evaluate(
+        self._model.evaluate(
             x=self._test_data,
             max_queue_size=32,
             workers=self._workers,

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -68,6 +68,7 @@ class core_trainer:
         self.period_save = json_data["period_save"]
         self.learning_rate = json_data["learning_rate"]
         self.verbose = json_data["verbose"]
+        self.json_data = json_data
         self._logger = logging.getLogger(__name__)
 
         if "checkpoints_dir" in json_data.keys():
@@ -378,7 +379,6 @@ class transfer_trainer(core_trainer):
 
     def __init__(
         self,
-        network_obj,
         generator_obj,
         test_generator_obj,
         trainer_json_path,
@@ -386,7 +386,7 @@ class transfer_trainer(core_trainer):
     ):
 
         super().__init__(
-            network_obj=network_obj,
+            network_obj=None,
             generator_obj=generator_obj,
             test_generator_obj=test_generator_obj,
             trainer_json_path=trainer_json_path,

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -373,7 +373,6 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
             x=self._test_data,
             max_queue_size=32,
             workers=self._workers,
-            shuffle=False,
             use_multiprocessing=self._use_multiprocessing,
             callbacks=[self._model_checkpoint_callback],
             verbose=self._verbose

--- a/deepinterpolation/trainor_collection.py
+++ b/deepinterpolation/trainor_collection.py
@@ -376,7 +376,7 @@ class ValidationCallback(tensorflow.keras.callbacks.Callback):
             shuffle=False,
             use_multiprocessing=self._use_multiprocessing,
             callbacks=[self._model_checkpoint_callback],
-            verbose=self.verbose
+            verbose=self._verbose
         )
 
 

--- a/tests/test_trainor_collection.py
+++ b/tests/test_trainor_collection.py
@@ -119,4 +119,4 @@ def test_ephys_training(tmp_path):
 
     # Validation is a bit random due to initilization. We check that you get
     # reasonable number
-    assert training_class.model_train.history["val_loss"][-1] < 10
+    assert training_class.val_loss[-1] < 10


### PR DESCRIPTION
This PR separates logging of train and validation. By default keras will only log a single line for both training and validation, including the time taken for both together. We were having issues with very long train times, and the time was dominated by validation. We needed to separate the logging of training and validation to get insight into the long train times. 

We separate the validation time by calling `.evaluate` instead of passing validation data into `.fit`. We create custom callbacks so that `evaluate` is called after every train epoch and `ModelCheckpoint` can be used with `evaluate`. 

Simplifies code.

# Testing

Manually tested. New logging looks like this:
```
2023-08-21 12:20:00 deepinterpolation.trainor_collection INFO     Epoch 1 train
Epoch 1/12
20/20 - 671s - loss: 0.9826 - 671s/epoch - 34s/step

2023-08-21 12:22:05 deepinterpolation.trainor_collection INFO     Epoch 1 validation
Epoch 1: loss improved from inf to 1.09220, saving model to /allen/aibs/informatics/aamster/di_test/1290677698_mean_squared_error-0001-1.0922.h5
83/83 - 403s - loss: 1.0922 - 403s/epoch - 5s/step

...
```

Before:
```
Epoch 2/156
20/20 [==============================] - 4376s 228s/step - loss: 0.9633 - val_loss: 0.8891
```